### PR TITLE
Add support for Laravel 5.4

### DIFF
--- a/src/BreadcrumbsServiceProvider.php
+++ b/src/BreadcrumbsServiceProvider.php
@@ -14,7 +14,7 @@ class BreadcrumbsServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app['breadcrumbs'] = $this->app->share(function ($app) {
+        $this->app->singleton('breadcrumbs', function ($app) {
             return new Breadcrumbs();
         });
 


### PR DESCRIPTION
As stated in the [Upgrade Guide](https://laravel.com/docs/5.4/upgrade) the `share` method is removed in Laravel 5.4.